### PR TITLE
Required log directory was missing/throwing error on init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.db
 node_modules/
 bower_components/
-logs/
+logs/*
 dist/

--- a/backend/public/logs/.gitignore
+++ b/backend/public/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Initializing higgsApi.js threw an error which sought out a path to the logs file in order to build an error log while the entire directory was ignored. Adding .gitignore to folder will mean presence of raw path but with content ignored. 